### PR TITLE
Change mruby_ldflags to mruby_libs for -lcrypto

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -5,8 +5,8 @@ MRuby::Gem::Specification.new('mruby-digest') do |spec|
   # spec.cflags = ''
  
   # spec.mruby_cflags = ''
-  spec.mruby_ldflags = ['-lcrypto']
-  # spec.mruby_libs = ''
+  # spec.mruby_ldflags = ''
+  spec.mruby_libs = '-lcrypto'
   # spec.mruby_includes = ["#{spec.dir}/include"]
  
   # spec.rbfiles = Dir.glob("#{dir}/mrblib/*.rb")


### PR DESCRIPTION
-lcryptoを呼ぶべきspecメソッドはmruby_libsなので、そちらに変更しておきました。
