### PR TITLE
remove unnecessary -lcrypto when targeting darwin

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -2,5 +2,5 @@ MRuby::Gem::Specification.new('mruby-digest') do |spec|
   spec.license = 'MIT'
   spec.authors = 'Internet Initiative Japan Inc.'
 
-  spec.linker.libraries << 'crypto'
+  spec.linker.libraries << 'crypto' unless RUBY_PLATFORM =~ /darwin/
 end


### PR DESCRIPTION
When building for OS X or iOS platforms, linker flags `-lcrypto` is not needed since we'are using not openssl but  Common Crypto.

And since Apple's iOS SDK does not ship with openssl by default, there will be an error while building for iOS platforms.

This patch adds a check and skip `-lcrypto` for darwin targets. 
