### PR TITLE
Fix memory leak on non Mac OS X.

### DIFF
--- a/src/digest.c
+++ b/src/digest.c
@@ -144,7 +144,7 @@ lib_md_digest(mrb_state *mrb, const struct mrb_md *md)
   unsigned char mdstr[EVP_MAX_MD_SIZE];
 
   EVP_MD_CTX_copy(&ctx, md->ctx);
-  EVP_DigestFinal_ex(&ctx, mdstr, &mdlen);
+  EVP_DigestFinal(&ctx, mdstr, &mdlen);
   return mrb_str_new(mrb, (char *)mdstr, mdlen);
 }
 


### PR DESCRIPTION
valgrind with the following script reports me a memory leak.

```
% cat foo.rb 
s = ((0..9).to_a + ("a".."z").to_a + ("A".."Z").to_a).sample(1024).join

puts Digest::SHA1.new.update(s)
% valgrind --leak-check=full ./bin/mruby foo.rb 
==18691== Memcheck, a memory error detector
==18691== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==18691== Using Valgrind-3.10.0 and LibVEX; rerun with -h for copyright info
==18691== Command: ./bin/mruby foo.rb
==18691== 
3bab4effb051249719d0d74426bfd98085e2b3eb
==18691== 
==18691== HEAP SUMMARY:
==18691==     in use at exit: 3,080 bytes in 109 blocks
==18691==   total heap usage: 4,641 allocs, 4,532 frees, 473,962 bytes allocated
==18691== 
==18691== 104 bytes in 1 blocks are definitely lost in loss record 107 of 109
==18691==    at 0x4C29BFD: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==18691==    by 0x51A02D2: CRYPTO_malloc (in /usr/lib64/libcrypto.so.1.0.1e)
==18691==    by 0x521F192: EVP_MD_CTX_copy_ex (in /usr/lib64/libcrypto.so.1.0.1e)
==18691==    by 0x455165: lib_md_digest (digest.c:146)
==18691==    by 0x4556AD: mrb_digest_digest (digest.c:574)
==18691==    by 0x455876: mrb_digest_hexdigest (digest.c:616)
==18691==    by 0x417E26: mrb_vm_exec (vm.c:1150)
==18691==    by 0x4165E2: mrb_vm_run (vm.c:759)
==18691==    by 0x41DD7B: mrb_top_run (vm.c:2434)
==18691==    by 0x438E3E: load_exec (parse.y:5681)
==18691==    by 0x438EB4: mrb_load_file_cxt (parse.y:5690)
==18691==    by 0x402AE6: main (mruby.c:226)
==18691== 
==18691== LEAK SUMMARY:
==18691==    definitely lost: 104 bytes in 1 blocks
==18691==    indirectly lost: 0 bytes in 0 blocks
==18691==      possibly lost: 0 bytes in 0 blocks
==18691==    still reachable: 2,976 bytes in 108 blocks
==18691==         suppressed: 0 bytes in 0 blocks
==18691== Reachable blocks (those to which a pointer was found) are not shown.
==18691== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==18691== 
==18691== For counts of detected and suppressed errors, rerun with: -v
==18691== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 1 from 1)
```