### PR TITLE
Fixed the broken codes in OpenSSL 1.1.0 and later

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,20 @@ install:
   - sudo apt-get -qq update
   - sudo apt-get -qq install build-essential rake bison git curl zlib1g-dev
 env:
-  - OPENSSL_VERSION=1.0.2
-  - OPENSSL_VERSION=1.1.0
+  global:
+    - CFLAGS=-I/opt/include LDFLAGS=-L/opt/lib
+  matrix:
+    - SSL_VERSION=openssl-1.0.2 DOWNLOAD_URL="https://www.openssl.org/source/${SSL_VERSION}-latest.tar.gz"
+    - SSL_VERSION=openssl-1.1.0 DOWNLOAD_URL="https://www.openssl.org/source/${SSL_VERSION}-latest.tar.gz"
+    - SSL_VERSION=libressl-2.5.5 DOWNLOAD_URL="https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/${SSL_VERSION}.tar.gz"
+    - SSL_VERSION=libressl-2.6.2 DOWNLOAD_URL="https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/${SSL_VERSION}.tar.gz"
 before_script:
-  - curl -sSfL "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}-latest.tar.gz" | tar xz
-  - pushd openssl-${OPENSSL_VERSION}*
+  - curl -sSfL $DOWNLOAD_URL | tar xz
+  - pushd ${SSL_VERSION}*
   - ./config --prefix=/opt shared zlib -fPIC > /dev/null
   - make > /dev/null
   - sudo make install_sw > /dev/null
   - popd
-  - sudo sh -c 'echo /opt/lib > /etc/ld.so.conf.d/openssl.conf'
-  - sudo ldconfig
-  - openssl version
+  - sudo ldconfig /opt/lib
 script:
   - "ruby run_test.rb all test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,20 @@
+dist: trusty
+sudo: required
+install:
+  - sudo apt-get -qq update
+  - sudo apt-get -qq install build-essential rake bison git curl zlib1g-dev
+env:
+  - OPENSSL_VERSION=1.0.2
+  - OPENSSL_VERSION=1.1.0
+before_script:
+  - curl -sSfL "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}-latest.tar.gz" | tar xz
+  - pushd openssl-${OPENSSL_VERSION}*
+  - ./config --prefix=/opt shared zlib -fPIC > /dev/null
+  - make > /dev/null
+  - sudo make install_sw > /dev/null
+  - popd
+  - sudo sh -c 'echo /opt/lib > /etc/ld.so.conf.d/openssl.conf'
+  - sudo ldconfig
+  - openssl version
 script:
   - "ruby run_test.rb all test"

--- a/src/digest.c
+++ b/src/digest.c
@@ -93,7 +93,7 @@ struct mrb_md {
 };
 
 struct mrb_hmac {
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined LIBRESSL_VERSION_NUMBER)
   HMAC_CTX *ctx;
 #else
   HMAC_CTX ctx;
@@ -120,7 +120,7 @@ lib_hmac_free(mrb_state *mrb, void *ptr)
   struct mrb_hmac *hmac = ptr;
 
   if (hmac != NULL) {
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined LIBRESSL_VERSION_NUMBER)
     HMAC_CTX_free(hmac->ctx);
 #else
     HMAC_CTX_cleanup(&hmac->ctx);
@@ -147,7 +147,7 @@ lib_md_block_length(const struct mrb_md *md)
 static mrb_value
 lib_md_digest(mrb_state *mrb, const struct mrb_md *md)
 {
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined LIBRESSL_VERSION_NUMBER)
   EVP_MD_CTX *ctx;
 #else
   EVP_MD_CTX ctx;
@@ -155,7 +155,7 @@ lib_md_digest(mrb_state *mrb, const struct mrb_md *md)
   unsigned int mdlen;
   unsigned char mdstr[EVP_MAX_MD_SIZE];
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined LIBRESSL_VERSION_NUMBER)
   ctx = EVP_MD_CTX_new();
   EVP_MD_CTX_copy(ctx, md->ctx);
   EVP_DigestFinal(ctx, mdstr, &mdlen);
@@ -246,7 +246,7 @@ lib_md_update(mrb_state *mrb, struct mrb_md *md, unsigned char *str, mrb_int len
 static mrb_value
 lib_hmac_digest(mrb_state *mrb, const struct mrb_hmac *hmac)
 {
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined LIBRESSL_VERSION_NUMBER)
   HMAC_CTX *ctx;
 #else
   HMAC_CTX ctx;
@@ -255,7 +255,7 @@ lib_hmac_digest(mrb_state *mrb, const struct mrb_hmac *hmac)
   unsigned char mdstr[EVP_MAX_MD_SIZE];
 
   memcpy(&ctx, &hmac->ctx, sizeof(ctx));
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined LIBRESSL_VERSION_NUMBER)
   HMAC_Final(ctx, mdstr, &mdlen);
 #else
   HMAC_Final(&ctx, mdstr, &mdlen);
@@ -284,7 +284,7 @@ lib_hmac_init(mrb_state *mrb, struct mrb_hmac *hmac, int type, const unsigned ch
   }
 #endif
   hmac->md = md_type_md(type);
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined LIBRESSL_VERSION_NUMBER)
   hmac->ctx = HMAC_CTX_new();
   HMAC_Init_ex(hmac->ctx, key, keylen, hmac->md, NULL);
 #else
@@ -301,7 +301,7 @@ lib_hmac_update(mrb_state *mrb, struct mrb_hmac *hmac, unsigned char *data, mrb_
       mrb_raise(mrb, E_ARGUMENT_ERROR, "too long string (not supported yet)");
   }
 #endif
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined LIBRESSL_VERSION_NUMBER)
   HMAC_Update(hmac->ctx, data, len);
 #else
   HMAC_Update(&hmac->ctx, data, len);

--- a/src/digest.c
+++ b/src/digest.c
@@ -93,7 +93,11 @@ struct mrb_md {
 };
 
 struct mrb_hmac {
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+  HMAC_CTX *ctx;
+#else
   HMAC_CTX ctx;
+#endif
   const EVP_MD *md;
 };
 
@@ -116,7 +120,11 @@ lib_hmac_free(mrb_state *mrb, void *ptr)
   struct mrb_hmac *hmac = ptr;
 
   if (hmac != NULL) {
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+    HMAC_CTX_free(hmac->ctx);
+#else
     HMAC_CTX_cleanup(&hmac->ctx);
+#endif
     mrb_free(mrb, hmac);
   }
 }
@@ -139,12 +147,23 @@ lib_md_block_length(const struct mrb_md *md)
 static mrb_value
 lib_md_digest(mrb_state *mrb, const struct mrb_md *md)
 {
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+  EVP_MD_CTX *ctx;
+#else
   EVP_MD_CTX ctx;
+#endif
   unsigned int mdlen;
   unsigned char mdstr[EVP_MAX_MD_SIZE];
 
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+  ctx = EVP_MD_CTX_new();
+  EVP_MD_CTX_copy(ctx, md->ctx);
+  EVP_DigestFinal(ctx, mdstr, &mdlen);
+  EVP_MD_CTX_free(ctx);
+#else
   EVP_MD_CTX_copy(&ctx, md->ctx);
   EVP_DigestFinal(&ctx, mdstr, &mdlen);
+#endif
   return mrb_str_new(mrb, (char *)mdstr, mdlen);
 }
 
@@ -227,12 +246,20 @@ lib_md_update(mrb_state *mrb, struct mrb_md *md, unsigned char *str, mrb_int len
 static mrb_value
 lib_hmac_digest(mrb_state *mrb, const struct mrb_hmac *hmac)
 {
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+  HMAC_CTX *ctx;
+#else
   HMAC_CTX ctx;
+#endif
   unsigned int mdlen;
   unsigned char mdstr[EVP_MAX_MD_SIZE];
 
   memcpy(&ctx, &hmac->ctx, sizeof(ctx));
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+  HMAC_Final(ctx, mdstr, &mdlen);
+#else
   HMAC_Final(&ctx, mdstr, &mdlen);
+#endif
   return mrb_str_new(mrb, (char *)mdstr, mdlen);
 }
 
@@ -257,8 +284,13 @@ lib_hmac_init(mrb_state *mrb, struct mrb_hmac *hmac, int type, const unsigned ch
   }
 #endif
   hmac->md = md_type_md(type);
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+  hmac->ctx = HMAC_CTX_new();
+  HMAC_Init_ex(hmac->ctx, key, keylen, hmac->md, NULL);
+#else
   HMAC_CTX_init(&hmac->ctx);
   HMAC_Init_ex(&hmac->ctx, key, keylen, hmac->md, NULL);
+#endif
 }
 
 static void
@@ -269,7 +301,11 @@ lib_hmac_update(mrb_state *mrb, struct mrb_hmac *hmac, unsigned char *data, mrb_
       mrb_raise(mrb, E_ARGUMENT_ERROR, "too long string (not supported yet)");
   }
 #endif
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+  HMAC_Update(hmac->ctx, data, len);
+#else
   HMAC_Update(&hmac->ctx, data, len);
+#endif
 }
 
 #elif defined(USE_DIGEST_OSX_COMMONCRYPTO)


### PR DESCRIPTION
iij/mruby-digest fails to build in Debian 9 because it installs OpenSSL 1.1.0 by default. I fixed this problem and updated the setting of Travis-CI to test both OpenSSL 1.0.2 and 1.1.0.